### PR TITLE
Support for latest sodium and ocaml-dns

### DIFF
--- a/src/ace/aced.ml
+++ b/src/ace/aced.ml
@@ -1,37 +1,46 @@
 open Lwt
-module Crypto = Sodium.Make(Sodium.Serialize.String)
+open Sodium
 module IPv4 = Ipaddr.V4
 
-let fresh_keyf () = None, Crypto.box_keypair ()
+let fresh_keyf () = None, Box.random_keypair ()
 
 let dns = Dns.Protocol.((module Client : CLIENT))
 
+let query_dns resolver _class _type _name =
+  Dns_resolver_unix.resolve resolver _class _type _name
+  >>= fun result ->
+  return (Some (Dns.Query.answer_of_response result))
+
 let serve sk pk server_pk domain =
   (* TODO: secure *)
-  Dns_resolver.create ()
+
+  (* Get signpost servers using system resolver *)
+  Dns_resolver_unix.create ()
   >>= fun sys_resolver ->
   let domain_string = Dns.Name.domain_name_to_string domain in
-  Dns_resolver.(gethostbyname sys_resolver domain_string)
+  Dns_resolver_unix.(gethostbyname sys_resolver domain_string)
   >>= fun signpost_base_ips ->
-  let signpost_ns = IPv4.to_string (List.hd signpost_base_ips) in
+  let signpost_ns = (List.hd signpost_base_ips) in
 
   let config = `Static ([signpost_ns,53],[]) in
   let client = Dnscurve_resolver.(
     between fresh_keyf (new_env ()) server_pk domain
       dns
-      (Control_protocol.auth_client None (pk,sk) server_pk dns)
+      (Control_protocol.auth_client None (sk,pk) server_pk dns)
   ) in
 
-  let resolver_service = ref (Dns_resolver.create ~client ~config ()) in
+  let resolver_service = ref (Dns_resolver_unix.create ~client ~config ()) in
   let reload_config config =
-    resolver_service := Dns_resolver.create ~client ~config () in
+    resolver_service := Dns_resolver_unix.create ~client ~config () in
 
   let dnsfn ~src ~dst packet =
-    !resolver_service >>= fun resolver ->
-    Dns_resolver.send_pkt resolver packet
-    >>= fun packet ->
-    Printf.printf "%s\n%!" (Dns.Packet.to_string packet);
-    return (Some (Dns.Query.answer_of_response packet))
+    let open Dns.Packet in
+    match packet.questions with 
+    | [q] -> begin
+		!resolver_service >>= fun resolver ->
+		query_dns resolver q.q_class q.q_type q.q_name
+             end
+    | _ -> return_none
   in
 
   let processor =
@@ -39,4 +48,4 @@ let serve sk pk server_pk domain =
 
   ignore (Lwt_unix.on_signal Sys.sighup (fun _ -> reload_config config));
   (* TODO: shed the privilege to bind a low port *)
-  Dns_server.serve_with_processor ~address:"127.0.0.1" ~port:53 ~processor
+  Dns_server_unix.serve_with_processor ~address:"127.0.0.1" ~port:53 ~processor

--- a/src/ace/spaced.ml
+++ b/src/ace/spaced.ml
@@ -1,6 +1,4 @@
 open Cmdliner
-module Crypto = Sodium.Make(Sodium.Serialize.String)
-module Base16_of = Base16.To_string
 
 let version = Version.string
 
@@ -22,10 +20,10 @@ let domain = Arg.(required & pos 3 (some string) None & info []
 
 let serve sk pk server_pk domain =
   Lwt_main.run begin
-    Crypto.(Aced.serve
-              (box_read_secret_key (Base16_of.string sk))
-              (box_read_public_key (Base16_of.string pk))
-              (box_read_public_key (Base16_of.string server_pk))
+    Sodium.Box.(Aced.serve
+              (Bytes.to_secret_key sk)
+              (Bytes.to_public_key pk)
+              (Bytes.to_public_key server_pk)
               (Dns.Name.string_to_domain_name domain))
   end
 

--- a/src/ace/spaced.ml
+++ b/src/ace/spaced.ml
@@ -1,4 +1,5 @@
 open Cmdliner
+module Base16_of = Base16.To_string
 
 let version = Version.string
 
@@ -21,9 +22,9 @@ let domain = Arg.(required & pos 3 (some string) None & info []
 let serve sk pk server_pk domain =
   Lwt_main.run begin
     Sodium.Box.(Aced.serve
-              (Bytes.to_secret_key sk)
-              (Bytes.to_public_key pk)
-              (Bytes.to_public_key server_pk)
+              (Bytes.to_secret_key (Base16_of.string sk))
+              (Bytes.to_public_key (Base16_of.string pk))
+              (Bytes.to_public_key (Base16_of.string server_pk))
               (Dns.Name.string_to_domain_name domain))
   end
 

--- a/src/base/spbased.ml
+++ b/src/base/spbased.ml
@@ -1,5 +1,6 @@
 open Cmdliner
 module Ipv4 = Ipaddr.V4
+module Base16_of = Base16.To_string
 
 let version = Version.string
 
@@ -25,11 +26,11 @@ let client_pk = Arg.(required & pos 4 (some string) None & info []
 
 let serve sk pk resolv_ip zone client_pk =
   Sodium.Box.(Based.serve
-            (Bytes.to_secret_key sk)
-            (Bytes.to_public_key pk)
+            (Bytes.to_secret_key (Base16_of.string sk))
+            (Bytes.to_public_key (Base16_of.string pk))
             resolv_ip
             (Dns.Name.string_to_domain_name zone)
-            (Bytes.to_public_key client_pk)
+            (Bytes.to_public_key (Base16_of.string client_pk))
   )
 
 let default_cmd =

--- a/src/base/spbased.ml
+++ b/src/base/spbased.ml
@@ -1,6 +1,4 @@
 open Cmdliner
-module Crypto = Sodium.Make(Sodium.Serialize.String)
-module Base16_of = Base16.To_string
 module Ipv4 = Ipaddr.V4
 
 let version = Version.string
@@ -26,12 +24,12 @@ let client_pk = Arg.(required & pos 4 (some string) None & info []
                        ~doc:"crypto_box public key for DNS tunneling")
 
 let serve sk pk resolv_ip zone client_pk =
-  Crypto.(Based.serve
-            (box_read_secret_key (Base16_of.string sk))
-            (box_read_public_key (Base16_of.string pk))
+  Sodium.Box.(Based.serve
+            (Bytes.to_secret_key sk)
+            (Bytes.to_public_key pk)
             resolv_ip
             (Dns.Name.string_to_domain_name zone)
-            (box_read_public_key (Base16_of.string client_pk))
+            (Bytes.to_public_key client_pk)
   )
 
 let default_cmd =

--- a/src/control_protocol.ml
+++ b/src/control_protocol.ml
@@ -7,7 +7,7 @@ let auth_client keyring ident server_pk inside =
   let module Client = struct
     include I
 
-    let marshal = I.marshal keyring ident
+    let marshal ?alloc = I.marshal keyring ident
   end in
   (module Client : CLIENT)
 

--- a/src/spkeygen.ml
+++ b/src/spkeygen.ml
@@ -1,11 +1,12 @@
 open Cmdliner
+module Base16_of = Base16.To_string
 
 let version = Version.string
 
 let keygen () =
   let (sk,pk) = Sodium.Box.random_keypair () in
-  let pk_s = Sodium.Box.Bytes.of_public_key pk in
-  let sk_s = Sodium.Box.Bytes.of_secret_key sk in
+  let pk_s = (Base16_of.t (Sodium.Box.Bytes.of_public_key pk)) in
+  let sk_s = (Base16_of.t (Sodium.Box.Bytes.of_secret_key sk)) in
   Printf.printf "Public key: %s\n" pk_s;
   Printf.printf "Secret key: %s\n" sk_s;
   ()

--- a/src/spkeygen.ml
+++ b/src/spkeygen.ml
@@ -1,13 +1,13 @@
 open Cmdliner
-module Crypto = Sodium.Make(Sodium.Serialize.String)
-module Base16_of = Base16.To_string
 
 let version = Version.string
 
 let keygen () =
-  let (pk,sk) = Crypto.box_keypair () in
-  Printf.printf "Public key: %s\n" (Base16_of.t (Crypto.box_write_key pk));
-  Printf.printf "Secret key: %s\n" (Base16_of.t (Crypto.box_write_key sk));
+  let (sk,pk) = Sodium.Box.random_keypair () in
+  let pk_s = Sodium.Box.Bytes.of_public_key pk in
+  let sk_s = Sodium.Box.Bytes.of_secret_key sk in
+  Printf.printf "Public key: %s\n" pk_s;
+  Printf.printf "Secret key: %s\n" sk_s;
   ()
 
 let default_cmd =


### PR DESCRIPTION
Compiles with latest libraries, but untested. Requires updated dnscurve from https://github.com/MagnusS/ocaml-dnscurve/tree/use_latest_libs (currently wip)
